### PR TITLE
arch-installer: make sure we have a current package database

### DIFF
--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -130,6 +130,13 @@ mkdir $ROOTFS/boot
 mount $BOOT_PART $ROOTFS/boot
 
 printf "\n### download and install base packages\n"
+# make sure we have a current package database and working
+# network connection
+pacman -Syy
+if [ $? = 1 ] ; then
+    echo "Cannot update package database - is the network up and running?"
+    exit 1
+fi
 pacman -Sg base | cut -d ' ' -f 2 | \
     sed -e /^linux\$/d       \
         -e /^mdadm/d         \


### PR DESCRIPTION
I had this fail on me claiming that there were no package databases for
core and extra. This surprised me, but forcing a "pacman -Syy" prior to
running "pacman -Sg base" makes sure this doesn't happen.

This always allows us to fail gracefully if there is a network problem
(e.g. if we are behind a proxy).

Signed-off-by: Dirk Hohndel dirk@hohndel.org
