### PR TITLE
arch-installer: add a shell hook

### DIFF
--- a/arch-installer-hooks/shell
+++ b/arch-installer-hooks/shell
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo
+echo The image is being built at
+echo
+echo "    ${ROOTFS}"
+echo
+echo Exit the shell to continue the process.
+echo
+
+cd ${ROOTFS}
+
+bash


### PR DESCRIPTION
Using `-x shell` instead of '-x bash` gives the shell already in the
ROOTFS directory and with a message to make clear that the image wasn't
finished.
