### PR TITLE
arch-installer: don't write new files in /dev/

### DIFF
--- a/arch-installer.sh
+++ b/arch-installer.sh
@@ -127,6 +127,11 @@ trap '
 # clean up after ourselves no matter how we die.
 trap 'exit 1;' SIGINT
 
+if [[ "$1" == /dev/* ]] && [[ ! -b "$1" ]]; then
+    echo "Couldn't find block device $1" >&2
+    exit 1
+fi
+
 if [[ ! -e "$1" ]] || [[ -f "$1" ]]; then
     dd if=/dev/null of="$1" bs=1M seek=4096
     DEV=$(losetup -f --show "$1")


### PR DESCRIPTION
A common mistake is to try to write the image into /dev/sd\* but for some
reason the device block is not there (USB not being properly
identified). Without this check, a new file would be created hiding the
mistake. So, assume that if the passed file is in /dev/ it must exist.
