### PR TITLE
git-fetchpr: add tool to easily get PR from github

### DIFF
--- a/git-fetchpr
+++ b/git-fetchpr
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+usage() {
+    echo "
+Usage: $(basename $0) [OPTIONS] <PR>
+Fetch a pull-request from github
+
+OPTIONS
+    -b <branch>    Branch on which to checkout this pr
+    -r <remote>    Use <remote> instead of origin to fetch the pr
+" 1>&$1;
+    exit $(($1 - 1));
+}
+
+OPT_BRANCH=""
+OPT_REMOTE="origin"
+args=0
+while getopts "b:r:h" o; do
+    case "${o}" in
+        b) OPT_BRANCH=${OPTARG}; args=$[$args + 2] ;;
+        r) OPT_REMOTE=${OPTARG}; args=$[$args + 2] ;;
+        h) usage 1;;
+        \?) usage 2;;
+    esac
+done
+shift $args
+
+PR=$1
+
+if [ -n "$OPT_BRANCH" ] && [ $(git rev-parse $OPT_BRANCH) ]; then
+    echo "Branch $OPT_BRANCH already exists" >&2
+    exit 1
+fi
+
+git fetch $OPT_REMOTE refs/pull/$PR/head:$OPT_BRANCH


### PR DESCRIPTION
Fetch a PR from github passing its number:

```
$ git fetchpr 3042
```

Like git fetch, use FETCH_HEAD as a pointer to the new PR:

```
$ git log FETCH_HEAD
$ tig FETCH_HEAD
```

It's possible to fetch from another remote, if for example you have a
fork of an upstream repository and someone is sending you a PR:

```
$ git fetchpr -r myremote 3042
```

You can also create a new branch straight from git-fetchpr:

```
$ git fetchpr -b pr/3042 3042
```
