### PR TITLE
git-fetchpr: fix ambiguity while checking out new branch

### DIFF
--- a/git-fetchpr
+++ b/git-fetchpr
@@ -33,7 +33,7 @@ fi
 
 PR=$1
 
-if [ -n "$OPT_BRANCH" ] && [ $(git rev-parse $OPT_BRANCH) ]; then
+if [ -n "$OPT_BRANCH" ] && [ $(git rev-parse $OPT_BRANCH --) ]; then
     echo "Branch $OPT_BRANCH already exists" >&2
     exit 1
 fi


### PR DESCRIPTION
Depending on the branch name, git may be confused if it's a path or a
branch name the argument to rev-parse:

++ git rev-parse review/pr-2722-pxf-battery
fatal: ambiguous argument 'review/pr-2722-pxf-battery': unknown revision
or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

Use a '--' in the end to fix it.
