### PR TITLE
kdeploy: Do not require remote to have sudo without password

### DIFF
--- a/kdeploy
+++ b/kdeploy
@@ -7,6 +7,17 @@ set -euo pipefail
 ## Following functions must be self-contained since they may be
 ## sent to a remote and executed there. Global params won't work
 
+local_sync_to_dest() {
+	local tmpdir="$1"
+	shift
+	local sync_files_args=("$@")
+
+	if [[ -z "$tmpdir" ]]; then
+		return
+	fi
+
+	rsync -tcKrv "${sync_files_args[@]}" --progress "$tmpdir/." /
+}
 
 initrd() {
 	local module_only=$1
@@ -83,6 +94,12 @@ usage() {
 	    --wait-remote-reboot	Like --remote-reboot (implied), but also wait it
 	                                come back [ default: no ]
 	    -t, --tmpdir[=] DIR		Directory to use for temporary installation
+	    --remote-tmpdir[=] DIR	Set the remote directory to use as temporary location
+	                                for installation. Set it to an empty string or "no" to
+	                                disable the use of a temporary location. It requires remote
+	                                user to have sudo permission without password,
+	                                i.e. '<user> ALL=(ALL) NOPASSWD: ALL' to be configured
+	                                in sudoers. [ default: /tmp/kdeploy ]
 
 	EXAMPLES:
 
@@ -145,6 +162,7 @@ OPT_REMOTE_USER=
 OPT_REMOTE_PORT=
 OPT_REMOTE_HOST=
 OPT_REMOTE_REBOOT=no
+OPT_REMOTE_TMPDIR=/tmp/kdeploy
 OPT_WAIT_REMOTE_REBOOT=no
 OPT_TMPDIR=
 OPT_CHDIR=
@@ -189,6 +207,11 @@ parse_args() {
 			shift "${args[0]}"
 			OPT_REMOTE_PORT="${args[2]}"
 			;;
+		--remote-tmpdir|--remote-tmpdir=*)
+			parse_arg_val args "$@"
+			shift "${args[0]}"
+			OPT_REMOTE_TMPDIR="${args[2]}"
+			;;
 		-t|--tmpdir|--tmpdir=*)
 			parse_arg_val args "$@"
 			shift "${args[0]}"
@@ -231,6 +254,10 @@ parse_args() {
 		SSH_REMOTE_ARGS+=("-l" "$OPT_REMOTE_USER")
 	fi
 
+	if [[ "$OPT_REMOTE_TMPDIR" == "no" ]]; then
+		OPT_REMOTE_TMPDIR=
+	fi
+
 	if [[ ${#OPT_MODULE_INCLUDE[@]} -gt 0 ]]; then
 		# include specific files given in the command line
 		readarray -t SYNC_FILES_ARGS< <(printf -- "--include=%s\n" "${OPT_MODULE_INCLUDE[@]}")
@@ -258,16 +285,22 @@ install_modules() {
 }
 
 sync_to_dest() {
+	local rsync_path=() rtmp
+
 	if [[ -n "$OPT_REMOTE_HOST" ]]; then
+		if [[ -n "$OPT_REMOTE_TMPDIR" ]]; then
+			rtmp=$OPT_REMOTE_TMPDIR
+		else
+			rsync_path+=("--rsync-path=sudo -u root rsync")
+			rtmp="/"
+		fi
 		rsync -tcKrv \
 			-e "ssh ${SSH_REMOTE_ARGS[*]}" \
-			--rsync-path="sudo -u root rsync" \
+			"${rsync_path[@]}" \
 			"${SYNC_FILES_ARGS[@]}" \
-			--progress "$OPT_TMPDIR/." "$OPT_REMOTE_HOST:/"
+			--progress "$OPT_TMPDIR/." "$OPT_REMOTE_HOST:$rtmp"
 	else
-		sudo rsync -tcKrv \
-			"${SYNC_FILES_ARGS[@]}" \
-			--progress "$OPT_TMPDIR/." /
+		sudo-function local_sync_to_dest "$OPT_TMPDIR" "${SYNC_FILES_ARGS[@]}"
 	fi
 }
 
@@ -277,9 +310,11 @@ post_kernel_install() {
 	if [[ -n "$OPT_REMOTE_HOST" ]]; then
 		set +e
 		# shellcheck disable=SC2029
-		typeset -f initrd -f bootloader -f reboot  | \
-			ssh "${SSH_REMOTE_ARGS[@]}" "$OPT_REMOTE_HOST" \
-			"sudo bash -c 'source /dev/stdin;	\
+		typeset -f initrd -f bootloader -f reboot -f local_sync_to_dest | \
+			ssh "${SSH_REMOTE_ARGS[@]}" "$OPT_REMOTE_HOST" -T "cat > /tmp/kdeploy-remote.sh"
+		ssh -t "${SSH_REMOTE_ARGS[@]}" "$OPT_REMOTE_HOST" \
+			"sudo -s bash -c 'source /tmp/kdeploy-remote.sh; 		\
+			 local_sync_to_dest $OPT_REMOTE_TMPDIR ${SYNC_FILES_ARGS[@]} && \
 			 initrd $OPT_MODULE_ONLY $krel &&	\
 			 bootloader $OPT_MODULE_ONLY && 	\
 			 reboot $OPT_REMOTE_REBOOT'"


### PR DESCRIPTION
It's much more common to have sudo with password. Make it the default, in which case we go through the following hops:

1) rsync to a local tmpdir (either created or passed in the command line) 2) rsync to a remote tmpdir, default to /tmp/kdeploy 3) ssh to remote to send script to execute
4) ssh to remote to finish execution, with sudo, possibly asking for
   password:
	- rsync from remote tmpdir to /
	- initrd
	- bootloader
	- reboot

When --remote-tmpdir= or --remote-tmpdir=no is passed, one rsync is avoided, but we still have same amount of logins:

1) rsync to a local tmpdir (either created or passed in the command line) 2) rsync to remote /
3) ssh to remote to send script to execute
4) ssh to remote to finish execution, with sudo, possibly asking for
   password:
	- initrd
	- bootloader
	- reboot

(3) and (4) is needed because we can't use ssh's stdin to send the script, otherwise a pty isn't created so sudo can't ask for password. In future we may move (3) to be done together with (2).