### PR TITLE
git-rewind-rebase: Improve argument parsing

### DIFF
--- a/git-rewind-rebase
+++ b/git-rewind-rebase
@@ -11,30 +11,41 @@
 # prepending the range <commit>..HEAD to the git-rebase's todo file.
 set -ex
 
-if [ $# -lt 1 ]; then
-    echo "missing commit to rebase onto" > /dev/stderr
-    exit 1
-fi
-commit=$1
+parse_args() {
+    if [ $# -lt 1 ]; then
+        echo "missing commit to rebase onto" > /dev/stderr
+        exit 1
+    fi
+    commit=$1
+}
 
-git_dir=$(git rev-parse --git-dir)
-todo="$git_dir/rebase-merge/git-rebase-todo"
+generate_new_todo() {
+    local git_dir
+    local todo
+    local new_todo
 
-if [ ! -f "$todo" ]; then
-    echo "Not in an interactive rebase?" > /dev/stderr
-    exit 1
-fi
+    git_dir=$(git rev-parse --git-dir)
+    todo="$git_dir/rebase-merge/git-rebase-todo"
 
-new_todo=$(mktemp --tmpdir git-rewind-rebase.XXXXXXXXXX)
+    if [ ! -f "$todo" ]; then
+        echo "Not in an interactive rebase?" > /dev/stderr
+        exit 1
+    fi
 
-git log --reverse $commit..HEAD --format="pick %H %s" > "$new_todo"
+    new_todo=$(mktemp --tmpdir git-rewind-rebase.XXXXXXXXXX)
 
-# insert a break so we are back to the previously stopped place
-echo "x echo \"rewind-rebase previously stopped here\"" >> "$new_todo"
-echo "break" >> "$new_todo"
+    git log --reverse $commit..HEAD --format="pick %H %s" > "$new_todo"
 
-cat "$todo" >> "$new_todo"
+    # insert a break so we are back to the previously stopped place
+    echo "x echo \"rewind-rebase previously stopped here\"" >> "$new_todo"
+    echo "break" >> "$new_todo"
 
-# replace todo
-mv "$new_todo" "$todo"
+    cat "$todo" >> "$new_todo"
+
+    # replace todo
+    mv "$new_todo" "$todo"
+}
+
+parse_args "$@"
+generate_new_todo
 git reset --hard $commit

--- a/git-rewind-rebase
+++ b/git-rewind-rebase
@@ -11,12 +11,14 @@
 # prepending the range <commit>..HEAD to the git-rebase's todo file.
 set -ex
 
+ARG_COMMIT=
+
 parse_args() {
     if [ $# -lt 1 ]; then
         echo "missing commit to rebase onto" > /dev/stderr
         exit 1
     fi
-    commit=$1
+    ARG_COMMIT=$1
 }
 
 generate_new_todo() {
@@ -34,7 +36,7 @@ generate_new_todo() {
 
     new_todo=$(mktemp --tmpdir git-rewind-rebase.XXXXXXXXXX)
 
-    git log --reverse $commit..HEAD --format="pick %H %s" > "$new_todo"
+    git log --reverse "$ARG_COMMIT..HEAD" --format="pick %H %s" > "$new_todo"
 
     # insert a break so we are back to the previously stopped place
     echo "x echo \"rewind-rebase previously stopped here\"" >> "$new_todo"
@@ -48,4 +50,4 @@ generate_new_todo() {
 
 parse_args "$@"
 generate_new_todo
-git reset --hard $commit
+git reset --hard "$ARG_COMMIT"

--- a/git-rewind-rebase
+++ b/git-rewind-rebase
@@ -1,23 +1,42 @@
 #!/bin/bash
-#
-# While in an interactive git-rebase, this allows to go back to a previous
-# commit without losing the changes already done so far.
-#
-# In other words, it allows the user to do "multiple passes" on the revision
-# range being updated in the same rebase section (i.e. no need to finish this
-# rebase and start a new one just because of a missed changed).
-#
-# This is achieved by hard-reseting to the commit passed as argument, and
-# prepending the range <commit>..HEAD to the git-rebase's todo file.
 set -e
 
+SCRIPT_FILENAME=$(basename "${BASH_SOURCE[0]}")
 ARG_COMMIT=
+
+usage() {
+    echo -n "\
+USAGE:
+    $SCRIPT_FILENAME [OPTIONS] <commit>
+
+While in an interactive git-rebase, this allows to go back to a previous
+commit without losing the changes already done so far.
+
+In other words, it allows the user to do \"multiple passes\" on the
+revision range being updated in the same rebase section (i.e. no need to
+finish this rebase and start a new one just because of a missed
+changed).
+
+This is achieved by hard-reseting to the commit passed as argument, and
+prepending the range <commit>..HEAD to the git-rebase's todo file.
+
+OPTIONS:
+    -h
+        Show this help message.
+"
+}
 
 parse_args() {
     if [ $# -lt 1 ]; then
         echo "missing commit to rebase onto" > /dev/stderr
         exit 1
     fi
+
+    if [[ $1 == -h ]]; then
+        usage
+        exit 0
+    fi
+
     ARG_COMMIT=$1
 }
 

--- a/git-rewind-rebase
+++ b/git-rewind-rebase
@@ -26,18 +26,37 @@ OPTIONS:
 "
 }
 
+argerr() {
+	echo "invalid argument: $*" >&2
+	echo >&2
+	usage >&2
+	exit 1
+}
+
 parse_args() {
-    if [ $# -lt 1 ]; then
-        echo "missing commit to rebase onto" > /dev/stderr
-        exit 1
-    fi
+    while (( $# > 0 )); do
+        case "$1" in
+        -h)
+            usage
+            exit 0
+            ;;
+        -*)
+            argerr "Unknown option $1."
+            ;;
+        *)
+            if [[ -n $ARG_COMMIT ]]; then
+                argerr "Commit specified more than once."
+            fi
 
-    if [[ $1 == -h ]]; then
-        usage
-        exit 0
-    fi
+            ARG_COMMIT=$1
+            ;;
+        esac
+        shift
+    done
 
-    ARG_COMMIT=$1
+    if [[ -z $ARG_COMMIT ]]; then
+        argerr "Missing commit to rebase onto."
+    fi
 }
 
 generate_new_todo() {

--- a/git-rewind-rebase
+++ b/git-rewind-rebase
@@ -9,7 +9,7 @@
 #
 # This is achieved by hard-reseting to the commit passed as argument, and
 # prepending the range <commit>..HEAD to the git-rebase's todo file.
-set -ex
+set -e
 
 ARG_COMMIT=
 


### PR DESCRIPTION
Improve `git-rewind-rebase`'s argument parsing by adding a -h option and also making it more robust against malformed arguments.